### PR TITLE
Fix issue with multiple location types being selected

### DIFF
--- a/app/assets/javascripts/results/result_list/result_list.html.slim
+++ b/app/assets/javascripts/results/result_list/result_list.html.slim
@@ -27,6 +27,5 @@ div ng-hide="$ctrl.data.isLoading"
   ul.no-bullet ng-if="$ctrl.data.providers.length"
     li.results-item ng-repeat="provider in $ctrl.data.providers"
       result provider="provider"
-      hr.margin-bottom-2
 
   results-pager current-page="$ctrl.data.currentPage" is-first-page="$ctrl.data.isFirstPage" is-last-page="$ctrl.data.isLastPage" page-size="$ctrl.data.pageSize" ng-if="$ctrl.data.providers.length"

--- a/app/assets/javascripts/results/results_filter_controller.js.coffee
+++ b/app/assets/javascripts/results/results_filter_controller.js.coffee
@@ -4,6 +4,11 @@ ResultsFilterController = ($scope, $modal, ResultsService) ->
   $scope.parent = ResultsService.parent
   $scope.showMoreFilters = false
 
+  $scope.$on 'search-service:updated', (event, service) ->
+    $scope.filters = service.filters
+    $scope.parent = service.parent
+    $scope.settings = service.searchSettings
+
   $scope.openResultFiltersModal = () ->
     $modal.open {
       templateUrl: 'results/result_filters_modal.html'

--- a/app/assets/javascripts/search/search_controller.js.coffee
+++ b/app/assets/javascripts/search/search_controller.js.coffee
@@ -74,6 +74,11 @@ SearchController = ($scope, $state, SearchService, $modal, $auth) ->
       false
 
   $scope.setLocationType = (type) ->
+#   Clean locations
+    $scope.filters.address = ""
+    $scope.filters.zipCodes = [""]
+    $scope.filters.neighborhoods = [""]
+
     $scope.locationTabs[type].active = true
     $scope.searchSettings.locationType = type
 

--- a/app/assets/javascripts/search/search_service.js.coffee
+++ b/app/assets/javascripts/search/search_service.js.coffee
@@ -34,15 +34,17 @@ SearchService = ($http, $cookies, CC_COOKIE, DataService, GeocodingService, Http
       if params.address.indexOf(', San Francisco, CA') == -1
         params.address += ', San Francisco, CA'
       params.distance = 2 # set the search radius in miles
+      delete params.zipCodes
+      delete params.neighborhoods
     else if $service.searchSettings.locationType == 'zipCodes' && params.zipCodes.length && params.zipCodes[0].length
       params.zip = params.zipCodes
       delete params.address
+      delete params.neighborhoods
     else if $service.searchSettings.locationType == 'neighborhoods' && params.neighborhoods.length && params.neighborhoods[0].length
       params.attributesLocal17 = params.neighborhoods
       delete params.address
+      delete params.zipCodes
 
-    delete params.neighborhoods
-    delete params.zipCodes
 
   # Reformat and rename program params to match API fields.
   $service.setPrograms = (params) ->


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160360131

When parent fills in an inputs for different types of locations they are all used instead of just one, currently selected.

TESTING
1. Go to: https://ccsf.wpengine.com/families/find-child-care/child-care-referrals/search-our-database/providers/
2. Edit filters
3. Change location type and pick one.
4. Change tab
5. Come back to previous tab. The content should be reseted.
6. Search
7. Reload the page
8. Search should remember your last selection